### PR TITLE
feat: implement restrict email settings configuration to Admin

### DIFF
--- a/src/Components/route-guard/admin-required.tsx
+++ b/src/Components/route-guard/admin-required.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../context/auth-context";
+
+interface AdminRequiredProps {
+  children: React.ReactNode;
+}
+
+const AdminRequired: React.FC<AdminRequiredProps> = ({ children }) => {
+  const { user } = useAuth();
+
+  if (!user || user.role !== "Admin") {
+    return <Navigate to="/anauthorized" />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminRequired;

--- a/src/Components/route-guard/anauthorized.tsx
+++ b/src/Components/route-guard/anauthorized.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from "react-router-dom";
+import Navbar from "../nav-bar/nav-bar";
+import LeftsideBar from "../leftside-bar/leftside-bar";
+import OrganiziationConfig from "../settings-dropdown/organization-configuration";
+
+const Anauthorized = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <Navbar />
+      <div className="flex flex-row">
+        <LeftsideBar />
+        <OrganiziationConfig />
+      </div>
+    </>
+  );
+};
+
+export default Anauthorized;

--- a/src/Components/settings-dropdown/organization-configuration.tsx
+++ b/src/Components/settings-dropdown/organization-configuration.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import { useAuth } from "../../context/auth-context";
+
+const OrganiziationConfig = () => {
+  const { user } = useAuth();
+  const organizationId = user.organization._id;
+  const [organizationName, setOrganizationName] = useState<string>("");
+  useEffect(() => {
+    console.log(user);
+    setOrganizationName(user.organization.name);
+  }, [organizationId]);
+  return (
+    <div className="flex-grow mx-auto align-middle text-left p-4 pr-8">
+      <h2 className="text-2xl font-bold mb-2.5">Organization Settings</h2>
+      <p className="text-gray-600 text-sm">View your current settings.</p>
+      <div className="flex flex-col mt-5">
+        <h3 className="text-lg font-semibold">General</h3>
+        <div className="flex flex-col gap-2.5 border-b py-2.5 border-gray-300 text-base">
+          <span className="text-[#96ACC1]">Organization Name:</span>
+          <span className="text-gray-700">{organizationName}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrganiziationConfig;

--- a/src/Components/settings-dropdown/setting-index.tsx
+++ b/src/Components/settings-dropdown/setting-index.tsx
@@ -1,34 +1,39 @@
 import React, { useEffect, useState } from "react";
 import { useAuth } from "../../context/auth-context";
-import "./settings.css";
 import { useNavigate } from "react-router-dom";
 import Navbar from "../nav-bar/nav-bar";
 import LeftsideBar from "../leftside-bar/leftside-bar";
 import { getEmailSettings } from "../../services/email-settings-service";
+import "./settings.css";
 
 const SettingsIndex: React.FC = () => {
   const navigate = useNavigate();
-  const { user } = useAuth();
-  const userId = user._id;
-  const organizationId = user.organization._id;
+  const { user } = useAuth(); // Access the user from auth context
   const [emailSettings, setEmailSettings] = useState<any>({});
   const [organizationName, setOrganizationName] = useState<string>("");
 
+  // Redirect to login if user is not authenticated
   useEffect(() => {
-    console.log(user);
-    setOrganizationName(user.organization.name);
+    if (!user) {
+      navigate("/login");
+    } else {
+      // Set the organization name
+      setOrganizationName(user.organization.name);
 
-    const fetchEmailSettings = async () => {
-      try {
-        const data = await getEmailSettings(organizationId);
-        setEmailSettings(data.responseObject);
-      } catch (error: any) {
-        console.error("Error fetching email settings:", error);
+      // If user is an admin, fetch email settings
+      if (user.role === "Admin") {
+        const fetchEmailSettings = async () => {
+          try {
+            const data = await getEmailSettings(user.organization._id);
+            setEmailSettings(data.responseObject);
+          } catch (error: any) {
+            console.error("Error fetching email settings:", error);
+          }
+        };
+        fetchEmailSettings();
       }
-    };
-
-    fetchEmailSettings();
-  }, [organizationId, userId]);
+    }
+  }, [user, navigate]);
 
   const handleEdit = () => {
     navigate("/email-configuration");
@@ -43,6 +48,8 @@ const SettingsIndex: React.FC = () => {
         <div className="flex-grow mx-auto align-middle text-left p-4 pr-8">
           <h2 className="text-2xl font-bold mb-2.5">Organization Settings</h2>
           <p className="text-gray-600 text-sm">View your current settings.</p>
+
+          {/* Show Organization Name */}
           <div className="flex flex-col mt-5">
             <h3 className="text-lg font-semibold">General</h3>
             <div className="flex flex-col gap-2.5 border-b py-2.5 border-gray-300 text-base">
@@ -51,7 +58,8 @@ const SettingsIndex: React.FC = () => {
             </div>
           </div>
 
-          {user.role === "Admin" && (
+          {/* Show additional settings if the user is an admin */}
+          {user?.role === "Admin" && (
             <div className="mt-8">
               <div className="flex justify-between">
                 <h3 className="text-lg font-semibold">Email Settings</h3>

--- a/src/Components/settings-dropdown/setting-index.tsx
+++ b/src/Components/settings-dropdown/setting-index.tsx
@@ -5,6 +5,7 @@ import Navbar from "../nav-bar/nav-bar";
 import LeftsideBar from "../leftside-bar/leftside-bar";
 import { getEmailSettings } from "../../services/email-settings-service";
 import "./settings.css";
+import OrganiziationConfig from "./organization-configuration";
 
 const SettingsIndex: React.FC = () => {
   const navigate = useNavigate();
@@ -45,11 +46,11 @@ const SettingsIndex: React.FC = () => {
       <Navbar />
       <div className="flex flex-row">
         <LeftsideBar />
+
         <div className="flex-grow mx-auto align-middle text-left p-4 pr-8">
           <h2 className="text-2xl font-bold mb-2.5">Organization Settings</h2>
           <p className="text-gray-600 text-sm">View your current settings.</p>
 
-          {/* Show Organization Name */}
           <div className="flex flex-col mt-5">
             <h3 className="text-lg font-semibold">General</h3>
             <div className="flex flex-col gap-2.5 border-b py-2.5 border-gray-300 text-base">
@@ -58,64 +59,60 @@ const SettingsIndex: React.FC = () => {
             </div>
           </div>
 
-          {/* Show additional settings if the user is an admin */}
-          {user?.role === "Admin" && (
-            <div className="mt-8">
-              <div className="flex justify-between">
-                <h3 className="text-lg font-semibold">Email Settings</h3>
-                <div className="actionButtons">
-                  <button
-                    onClick={handleEdit}
-                    className="bg-gray-600 text-white px-4 py-1 rounded-md hover:bg-blue-600"
-                  >
-                    Edit
-                  </button>
+          {/* This is email settings-configuration  section accessible Admin only */}
+          <div className="mt-8">
+            <div className="flex justify-between">
+              <h3 className="text-lg font-semibold">Email Settings</h3>
+              <div className="actionButtons">
+                <button
+                  onClick={handleEdit}
+                  className="bg-gray-600 text-white px-4 py-1 rounded-md hover:bg-blue-600"
+                >
+                  Edit
+                </button>
+              </div>
+            </div>
+            <div className="mt-5">
+              <div className="border-b border-gray-300 grid grid-cols-2 mb-2.5">
+                <div className="text-base">
+                  <p className="text-[#96ACC1]">Server:</p>
+                  <span className="text-gray-700">{emailSettings?.server}</span>
+                </div>
+                <div className="text-base">
+                  <p className="text-[#96ACC1]">Verified Sender Email:</p>
+                  <span className="text-gray-700">
+                    {emailSettings?.verified_sender_email}
+                  </span>
                 </div>
               </div>
-              <div className="mt-5">
-                <div className="border-b border-gray-300 grid grid-cols-2 mb-2.5">
-                  <div className="text-base">
-                    <p className="text-[#96ACC1]">Server:</p>
-                    <span className="text-gray-700">
-                      {emailSettings?.server}
-                    </span>
-                  </div>
-                  <div className="text-base">
-                    <p className="text-[#96ACC1]">Verified Sender Email:</p>
-                    <span className="text-gray-700">
-                      {emailSettings?.verified_sender_email}
-                    </span>
-                  </div>
+              <div className="border-b py-2.5 border-gray-300 grid grid-cols-2 mb-2.5">
+                <div className="text-base">
+                  <p className="text-[#96ACC1]">Username:</p>
+                  <span className="text-gray-700">
+                    {emailSettings?.username}
+                  </span>
                 </div>
-                <div className="border-b py-2.5 border-gray-300 grid grid-cols-2 mb-2.5">
-                  <div className="text-base">
-                    <p className="text-[#96ACC1]">Username:</p>
-                    <span className="text-gray-700">
-                      {emailSettings?.username}
-                    </span>
-                  </div>
-                  <div className="text-base">
-                    <p className="text-[#96ACC1]">Password:</p>
-                    <span className="text-gray-700">
-                      {emailSettings?.password ? "***********" : ""}
-                    </span>
-                  </div>
+                <div className="text-base">
+                  <p className="text-[#96ACC1]">Password:</p>
+                  <span className="text-gray-700">
+                    {emailSettings?.password ? "***********" : ""}
+                  </span>
                 </div>
-                <div className="border-b py-2.5 border-gray-300 grid grid-cols-2 mb-2.5">
-                  <div className="text-base">
-                    <p className="text-[#96ACC1]">Security Type:</p>
-                    <span className="text-gray-700">
-                      {emailSettings?.securityType}
-                    </span>
-                  </div>
-                  <div className="text-base">
-                    <p className="text-[#96ACC1]">Port:</p>
-                    <span className="text-gray-700">{emailSettings?.port}</span>
-                  </div>
+              </div>
+              <div className="border-b py-2.5 border-gray-300 grid grid-cols-2 mb-2.5">
+                <div className="text-base">
+                  <p className="text-[#96ACC1]">Security Type:</p>
+                  <span className="text-gray-700">
+                    {emailSettings?.securityType}
+                  </span>
+                </div>
+                <div className="text-base">
+                  <p className="text-[#96ACC1]">Port:</p>
+                  <span className="text-gray-700">{emailSettings?.port}</span>
                 </div>
               </div>
             </div>
-          )}
+          </div>
         </div>
       </div>
     </>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,8 @@ import AuthRequired from "./Components/auth-required/auth-required";
 import { useAuth } from "./context/auth-context";
 import { checkUser, logoutUser } from "./services/auth";
 import EmailConfiguration from "./Components/settings-dropdown/email-configuration";
+import AdminRequired from "./Components/route-guard/admin-required";
+import Anauthorized from "./Components/route-guard/anauthorized";
 
 const HomePage = () => {
   const { setUser } = useAuth();
@@ -35,10 +37,26 @@ const App = () => {
         <Route element={<AuthRequired />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/anauthorized" element={<Anauthorized />} />
 
-          <Route path="/setting-index" element={<SettingsIndex />} />
-
-          <Route path="/email-configuration" element={<EmailConfiguration />} />
+          {/* Admin-Only Routes */}
+          <Route
+            path="/setting-index"
+            element={
+              <AdminRequired>
+                <SettingsIndex />
+              </AdminRequired>
+            }
+          />
+          <Route
+            path="/email-configuration"
+            element={
+              <AdminRequired>
+                <EmailConfiguration />
+              </AdminRequired>
+            }
+          />
+          {/* Admin-Only Routes ends here*/}
         </Route>
         <Route path="/login" element={<Login />} />
       </Routes>


### PR DESCRIPTION
## Ticket

ID: #13
Link:https://project-ascend-io.atlassian.net/browse/PAP-209

## Problem

Admin and non-admin users can view, edit, and configure email settings, violating the intended access controls.

## Solution

Access controls have been implemented to restrict non-admin users. Only admin users will have full access to view, edit, and configure email settings, while non-admin users will have view-only permissions.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The solution was tested locally by logging in with different user roles, both as an admin and a non-admin, to verify access restrictions and ensure that only admin users have full access to email settings.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
<img width="400" alt="Screenshot 2024-10-22 at 10 05 13 PM" src="https://github.com/user-attachments/assets/b60a8d65-b14d-404b-a0f2-d73d973f2256">


